### PR TITLE
Autosurround support

### DIFF
--- a/src/languages/twig.configuration.json
+++ b/src/languages/twig.configuration.json
@@ -8,5 +8,13 @@
 		["{", "}"],
 		["[", "]"],
 		["(", ")"]
+	],
+	"surroundingPairs": [
+		{ "open": "'", "close": "'" },
+		{ "open": "\"", "close": "\"" },
+		{ "open": "{", "close": "}"},
+		{ "open": "[", "close": "]"},
+		{ "open": "(", "close": ")" },
+		{ "open": "<", "close": ">" }
 	]
 }


### PR DESCRIPTION
This change replicates the [default HTML configuration](https://github.com/Microsoft/vscode/blob/master/extensions/html/language-configuration.json). When you select some text and hit any of the surrounding pair keys the string will be wrapped with the corresponding open/close characters, instead of being overwritten.

Perhaps the `autoClosingPairs` defaults should be replicated too?