### PR TITLE
Add support for {% scss %} tags

### DIFF
--- a/src/syntaxes/twig.tmLanguage
+++ b/src/syntaxes/twig.tmLanguage
@@ -418,6 +418,25 @@
         </dict>
         <dict>
             <key>begin</key>
+            <string>(?ix)   # Enable free spacing mode, case insensitive
+                        (?&lt;=\{\%\sscss\s\%\}|\{\%\sincludescss\s\%\}|\{\%\sincludehiresscss\s\%\})
+                        </string>
+            <key>comment</key>
+            <string>Add SCSS support to set tags that use the pattern "scss" in their name</string>
+            <key>end</key>
+            <string>(?ix)(?=\{\%\sendscss\s\%\}|\{\%\sendincludescss\s\%\}|\{\%\sendincludehiresscss\s\%\})</string>
+            <key>name</key>
+            <string>source.css.scss.embedded.twig</string>
+            <key>patterns</key>
+            <array>
+                <dict>
+                    <key>include</key>
+                    <string>source.css.scss</string>
+                </dict>
+            </array>
+        </dict>
+        <dict>
+            <key>begin</key>
             <string>(&lt;/?)((?i:body|head|html)\b)</string>
             <key>captures</key>
             <dict>


### PR DESCRIPTION
Add support for {% scss %} tags ( usage of https://github.com/chasegiunta/scss )

I really just copy pasted the Dict block and added a S before css everywhere, but I know nothing about tmlanguage files etc. It did work when I applied the change locally, so I figured it might help other people ! 

Don't hesitate to throw the PR in the trash if it's far from complete, breaks other things, etc of course. Just figured it might help someone else ! 

Thanks for this package