### PR TITLE
Fix trans snippet

### DIFF
--- a/src/snippets/snippets.json
+++ b/src/snippets/snippets.json
@@ -666,7 +666,7 @@
     },
     "trans": {
         "prefix": "trans",
-        "body": "{% trans %}$0{% trans %}",
+        "body": "{% trans %}$0{% endtrans %}",
         "description": "trans",
         "scope": "text.html.twig"
     },


### PR DESCRIPTION
The snippet used `trans` as the end of the block instead of `endtrans`.

Fix #72 