### PR TITLE
Add logic operators highlight inside arrays and hashes

### DIFF
--- a/src/syntaxes/twig.tmLanguage
+++ b/src/syntaxes/twig.tmLanguage
@@ -1682,6 +1682,10 @@
                 </dict>
                 <dict>
                     <key>include</key>
+                    <string>#twig-operators</string>
+                </dict>
+                <dict>
+                    <key>include</key>
                     <string>#twig-functions-warg</string>
                 </dict>
                 <dict>

--- a/src/syntaxes/twig.tmLanguage
+++ b/src/syntaxes/twig.tmLanguage
@@ -1371,6 +1371,10 @@
                 </dict>
                 <dict>
                     <key>include</key>
+                    <string>#twig-operators</string>
+                </dict>
+                <dict>
+                    <key>include</key>
                     <string>#twig-strings</string>
                 </dict>
                 <dict>

--- a/src/syntaxes/twig.tmLanguage
+++ b/src/syntaxes/twig.tmLanguage
@@ -1279,6 +1279,10 @@
                 </dict>
                 <dict>
                     <key>include</key>
+                    <string>#twig-operators</string>
+                </dict>
+                <dict>
+                    <key>include</key>
                     <string>#twig-strings</string>
                 </dict>
                 <dict>

--- a/src/syntaxes/twig.tmLanguage
+++ b/src/syntaxes/twig.tmLanguage
@@ -951,7 +951,7 @@
                         </dict>
                     </dict>
                     <key>match</key>
-                    <string>(?&lt;=\s)(\?|:|and|not|or)(?=\s)</string>
+                    <string>(?&lt;=\s)(\?|:|\?:|\?\?|and|not|or)(?=\s)</string>
                 </dict>
 
                 <!-- RANGE -->


### PR DESCRIPTION
In the project I'm working on, it happens that I have ternary expression inside arrays and hashes. In the current version of Twig Language 2, it does not highlight logic operators.

## In arrays

Here's what it looked like before

![Capture d’écran, le 2023-04-20 à 15 17 04](https://user-images.githubusercontent.com/128060447/233469741-8ea505a6-a0a9-46ff-9352-8f3cf50728f0.png)

Here's what it looks like now

![Capture d’écran, le 2023-04-20 à 15 16 11](https://user-images.githubusercontent.com/128060447/233469795-97ea6a67-16f6-4149-af55-35b03617e9f6.png)

## In hashes

Here's what it looked like before

![Capture d’écran, le 2023-04-21 à 11 15 45](https://user-images.githubusercontent.com/128060447/233674025-6abadb71-f16a-4a3e-b5c4-26b0fc1dcc70.png)

Here's what it looks like now

![Capture d’écran, le 2023-04-21 à 11 16 21](https://user-images.githubusercontent.com/128060447/233674050-c72996fe-1dc8-4184-bf83-3f84e553061e.png)

## In filters

Here's what it looked like before

![Capture d’écran, le 2023-04-21 à 11 39 34](https://user-images.githubusercontent.com/128060447/233680375-8827a1b9-c4d3-42a5-abc9-8decdfd76069.png)

Here's what it looks like now

![Capture d’écran, le 2023-04-21 à 11 50 56](https://user-images.githubusercontent.com/128060447/233680400-24897b19-5896-436c-8fae-a06de96aaade.png)

## Added ternary operators

I also added `?:` and `??` ternary operators in the regex string. These operators are in the Twig v3 documentations : https://twig.symfony.com/doc/3.x/templates.html#other-operators.

Here's what it looked like before

![Capture d’écran, le 2023-04-21 à 10 21 44](https://user-images.githubusercontent.com/128060447/233661266-82193bd5-46a1-4ac8-82c2-db46b6346c1a.png)

Here's what it looks like now

![Capture d’écran, le 2023-04-21 à 10 20 33](https://user-images.githubusercontent.com/128060447/233661302-79f17e92-7d1e-4e3e-9157-4a04a579468f.png)
